### PR TITLE
投稿：管理员绿帽、减少元素间距

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ plugins (所有的插件目录)
 
 | 名称 | 用户样式 | 作者 | 说明 |
 | --- | --- | --- | --- |
+| [admin_s_green_hat](https://github.com/sileence114/ntqq_user_script/blob/main/README.md#admin_s_green_hat) | 🟢 | [sileence114](https://github.com/sileence114) | 让管理员戴回绿帽（将管理员头衔颜色重新改为绿色） |
 | [auto-fold-chat-input-area](https://github.com/lamprose/transitio-css#auto-fold-chat-input-area) | 🔴 | [lamprose](https://github.com/lamprose) | 消息输入框默认折叠有文字输入时展开 |
 | [avatar-float](https://github.com/PRO-2684/Transitio-user-css/#avatar-float) | 🟢 | [PRO-2684](https://github.com/PRO-2684) | 头像浮动 |
 | [avatar-the-bubbles](https://gist.github.com/BingZi-233/bfed496741624cc2e51aa7c9cdfca78a) | 🟢 | [BingZi-233](https://github.com/BingZi-233) | 头像描边 |

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ plugins (所有的插件目录)
 
 | 名称 | 用户样式 | 作者 | 说明 |
 | --- | --- | --- | --- |
-| [admin_s_green_hat](https://github.com/sileence114/ntqq_user_script/blob/main/README.md#admin_s_green_hat) | 🟢 | [sileence114](https://github.com/sileence114) | 让管理员戴回绿帽（将管理员头衔颜色重新改为绿色） |
+| [admin-s-green-hat](https://github.com/sileence114/ntqq_user_script/blob/main/README.md#admin-s-green-hat) | 🟢 | [sileence114](https://github.com/sileence114) | 让管理员戴回绿帽（将管理员头衔颜色重新改为绿色） |
 | [auto-fold-chat-input-area](https://github.com/lamprose/transitio-css#auto-fold-chat-input-area) | 🔴 | [lamprose](https://github.com/lamprose) | 消息输入框默认折叠有文字输入时展开 |
 | [avatar-float](https://github.com/PRO-2684/Transitio-user-css/#avatar-float) | 🟢 | [PRO-2684](https://github.com/PRO-2684) | 头像浮动 |
 | [avatar-the-bubbles](https://gist.github.com/BingZi-233/bfed496741624cc2e51aa7c9cdfca78a) | 🟢 | [BingZi-233](https://github.com/BingZi-233) | 头像描边 |
@@ -97,11 +97,12 @@ plugins (所有的插件目录)
 | [Hide-the-Import-Phone-Album-feature-in-the-upper-right-corner-of-the-My-Phone-Chat-window](https://github.com/YatFanLan/Hide-the-Import-Phone-Album-feature-in-the-upper-right-corner-of-the-My-Phone-Chat-window) | 🟢 |[YatFanLan](https://github.com/YatFanLan) | 隐藏我的手机聊天窗口中右上角的导入手机相册功能|
 | [hide-lock](https://github.com/PRO-2684/Transitio-user-css/#hide-lock) | 🟢 | [Shapaper233](https://github.com/Shapaper233) | 隐藏侧边栏 "更多" 中倒数第四个按钮 ("锁定") |
 | [hide-self](https://github.com/PRO-2684/Transitio-user-css/#hide-self) | 🟢 | [PRO-2684](https://github.com/PRO-2684) | 隐藏自己的头像和昵称 |
-| [ Hide-the-QQ-Space-option-on-the-Friends-Information-screen](https://github.com/YatFanLan/Hide-the-QQ-Space-option-on-the-Friends-Information-screen) | 🟢 | [YatFanLan](https://github.com/YatFanLan) |  隐藏好友信息界面的QQ空间选项|
+| [Hide-the-QQ-Space-option-on-the-Friends-Information-screen](https://github.com/YatFanLan/Hide-the-QQ-Space-option-on-the-Friends-Information-screen) | 🟢 | [YatFanLan](https://github.com/YatFanLan) |  隐藏好友信息界面的QQ空间选项|
 | [highlight-at](https://github.com/PRO-2684/Transitio-user-css/#highlight-at) | 🟢 | [PRO-2684](https://github.com/PRO-2684) | 高亮艾特 |
 | [image-viewer](https://github.com/PRO-2684/Transitio-user-css/#image-viewer) | 🟢 | [PRO-2684](https://github.com/PRO-2684) | 媒体查看器透明度修改 |
 | [ImageSize](https://github.com/zhuoxin-lzk/transitio-ImageSize) | 🔴 | [zhuoxin-lzk](https://github.com/zhuoxin-lzk) | 限制图片和表情显示大小 |
 | [input-placeholder](https://github.com/PRO-2684/Transitio-user-css/#input-placeholder) | 🟢 | [PRO-2684](https://github.com/PRO-2684) | 添加输入框提示（占位符） |
+| [less-spacing](https://github.com/sileence114/ntqq_user_script/blob/main/README.md#less-spacing) | 🟢 | [sileence114](https://github.com/sileence114) | 减少元素间距 |
 | [link-color](https://github.com/PRO-2684/Transitio-user-css/#link-color) | 🟢 | [PRO-2684](https://github.com/PRO-2684) | 链接动态颜色：悬浮/按下时显示相应颜色。 |
 | [lite-tools-recall-enhancement](https://github.com/PRO-2684/Transitio-user-css/#lite-tools-recall-enhancement) | 🟢 | [Shapaper233](https://github.com/Shapaper233) | 给 lite-tools 的撤回消息加上红色增强描边 |
 | [message-img-transparent](https://github.com/lamprose/transitio-css#message-img-transparent) | 🔴 | [lamprose](https://github.com/lamprose) | 包含图片消息背景透明 |


### PR DESCRIPTION
> 直接复制了readme(

## user css
### [admin-s-green-hat](https://raw.githubusercontent.com/sileence114/ntqq_user_script/refs/heads/main/css/admin-s-green-hat.css)
| 浅色模式 | 深色模式 |
| --- | --- |
| ![b6ab7d2a3bcc1dc8516639d2e46cd098](https://github.com/user-attachments/assets/5d387de6-6c7a-405f-a1af-70d0f39e1c81) | ![c8d162630b23e6fe11fb8a6e0a5b9eb6](https://github.com/user-attachments/assets/9552b6ac-57fc-4a9d-b184-0407e981fa7d) |
> 让管理员戴回绿帽（将管理员头衔颜色重新改为绿色）
- 如果不喜欢我调的颜色，你可以在设置中自己调整
- 支持深色模式

### [less-spacing](https://raw.githubusercontent.com/sileence114/ntqq_user_script/refs/heads/main/css/less-spacing.css)
| 未启用 | 启用后 |
| --- | --- |
![image](https://github.com/user-attachments/assets/c3cd0853-1c7a-417d-9bd9-7dafe040542e) | ![image](https://github.com/user-attachments/assets/579b5136-e40e-4151-a911-d808604f1a4a)
> 减少元素间距
> （后续优化方向）尽量减少列表项的间距，让窗口显示更多内容。
- 已调整：
  - 消息列表
  - 转发的聊天记录
  - 聊天区域
- 画饼：
  - 适配轻量工具箱的合并消息模式
  - 聊天记录窗口
- 有点麻烦？（PR Please!）
  - 群聊窗口边栏成员列表（虚拟滚动区域列表元素数量有限，会露出空白的列表元素）
  - 其他犄角旮旯的地方
